### PR TITLE
Annotation Feature: Added Min and Max Annotations

### DIFF
--- a/vador/src/main/java/com/salesforce/vador/annotation/MaxForInt.kt
+++ b/vador/src/main/java/com/salesforce/vador/annotation/MaxForInt.kt
@@ -1,0 +1,23 @@
+package com.salesforce.vador.annotation
+
+import com.salesforce.vador.types.ValidatorAnnotation2
+import java.lang.reflect.Field
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class MaxForInt(val limit: Int, val failureKey: String)
+
+class MaxForIntValidator<FailureT> : ValidatorAnnotation2<Int, FailureT> {
+  override fun validate(
+    field: Field,
+    value1: Int,
+    value2: Int,
+    failure: FailureT,
+    none: FailureT
+  ): FailureT {
+    if (value1 > value2) {
+      return failure
+    }
+    return none
+  }
+}

--- a/vador/src/main/java/com/salesforce/vador/annotation/MinForInt.kt
+++ b/vador/src/main/java/com/salesforce/vador/annotation/MinForInt.kt
@@ -1,0 +1,23 @@
+package com.salesforce.vador.annotation
+
+import com.salesforce.vador.types.ValidatorAnnotation2
+import java.lang.reflect.Field
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class MinForInt(val limit: Int, val failureKey: String)
+
+class MinForIntValidator<FailureT> : ValidatorAnnotation2<Int, FailureT> {
+  override fun validate(
+    field: Field,
+    value1: Int,
+    value2: Int,
+    failure: FailureT,
+    none: FailureT
+  ): FailureT {
+    if (value1 < value2) {
+      return failure
+    }
+    return none
+  }
+}

--- a/vador/src/main/java/com/salesforce/vador/annotation/Negative.kt
+++ b/vador/src/main/java/com/salesforce/vador/annotation/Negative.kt
@@ -3,7 +3,11 @@ package com.salesforce.vador.annotation
 import com.salesforce.vador.types.ValidatorAnnotation1
 import java.lang.reflect.Field
 
-class Negative<FailureT> : ValidatorAnnotation1<Int, FailureT> {
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class Negative(val failureKey: String)
+
+class NegativeValidator<FailureT> : ValidatorAnnotation1<Int, FailureT> {
   override fun validate(field: Field, value: Int, failure: FailureT, none: FailureT): FailureT {
     if (value > -1) {
       return failure

--- a/vador/src/main/java/com/salesforce/vador/annotation/NonNegative.kt
+++ b/vador/src/main/java/com/salesforce/vador/annotation/NonNegative.kt
@@ -3,7 +3,11 @@ package com.salesforce.vador.annotation
 import com.salesforce.vador.types.ValidatorAnnotation1
 import java.lang.reflect.Field
 
-class NonNegative<FailureT> : ValidatorAnnotation1<Int, FailureT> {
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class NonNegative(val failureKey: String)
+
+class NonNegativeValidator<FailureT> : ValidatorAnnotation1<Int, FailureT> {
   override fun validate(field: Field, value: Int, failure: FailureT, none: FailureT): FailureT {
     if (value < 0) {
       return failure

--- a/vador/src/main/java/com/salesforce/vador/annotation/Positive.kt
+++ b/vador/src/main/java/com/salesforce/vador/annotation/Positive.kt
@@ -3,7 +3,11 @@ package com.salesforce.vador.annotation
 import com.salesforce.vador.types.ValidatorAnnotation1
 import java.lang.reflect.Field
 
-class Positive<FailureT> : ValidatorAnnotation1<Int, FailureT> {
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class Positive(val failureKey: String)
+
+class PositiveValidator<FailureT> : ValidatorAnnotation1<Int, FailureT> {
   override fun validate(field: Field, value: Int, failure: FailureT, none: FailureT): FailureT {
     if (value < 1) {
       return failure

--- a/vador/src/main/java/com/salesforce/vador/execution/strategies/AnnotationProcessor.kt
+++ b/vador/src/main/java/com/salesforce/vador/execution/strategies/AnnotationProcessor.kt
@@ -1,9 +1,20 @@
 package com.salesforce.vador.execution.strategies
 
+import com.salesforce.vador.annotation.MaxForInt
+import com.salesforce.vador.annotation.MaxForIntValidator
+import com.salesforce.vador.annotation.MinForInt
+import com.salesforce.vador.annotation.MinForIntValidator
+import com.salesforce.vador.annotation.Negative
+import com.salesforce.vador.annotation.NegativeValidator
+import com.salesforce.vador.annotation.NonNegative
+import com.salesforce.vador.annotation.NonNegativeValidator
+import com.salesforce.vador.annotation.Positive
+import com.salesforce.vador.annotation.PositiveValidator
 import com.salesforce.vador.annotation.ValidateWith
 import com.salesforce.vador.lift.liftToEtr
 import com.salesforce.vador.types.Validator
 import com.salesforce.vador.types.ValidatorAnnotation1
+import com.salesforce.vador.types.ValidatorAnnotation2
 import com.salesforce.vador.types.ValidatorEtr
 import io.vavr.Tuple2
 import java.lang.reflect.InvocationTargetException
@@ -24,27 +35,120 @@ object AnnotationProcessorBase {
     val map = mapOfAnnotation?._1()
     val none = mapOfAnnotation?._2()
     return fields.mapNotNull { field ->
-      if (field.isAnnotationPresent(ValidateWith::class.java)) {
-        val annotation = field.getAnnotation(ValidateWith::class.java)
-        val failureKey = annotation.failureKey
-        if (ValidatorAnnotation1::class.java.isAssignableFrom(annotation.validator.java)) {
-          val validatorAnnotation =
-            annotation.validator.java.getDeclaredConstructor().newInstance()
-              as ValidatorAnnotation1<Any, FailureT?>
-          val validator =
-            Validator<ValidatableT?, FailureT?> {
-              validatorAnnotation.validate(
-                field,
-                FieldUtils.readField(field, bean, true) as Any,
-                map?.get(failureKey),
-                none,
+      if (field.annotations.isNotEmpty()) {
+        val validator: Validator<ValidatableT?, FailureT?>
+        when (field.annotations[0].annotationClass.simpleName) {
+          "ValidateWith" -> {
+            val annotation = field.getAnnotation(ValidateWith::class.java)
+            val failureKey = annotation.failureKey
+            if (ValidatorAnnotation1::class.java.isAssignableFrom(annotation.validator.java)) {
+              val validatorAnnotation =
+                annotation.validator.java.getDeclaredConstructor().newInstance()
+                  as ValidatorAnnotation1<Any, FailureT?>
+              validator =
+                Validator<ValidatableT?, FailureT?> {
+                  validatorAnnotation.validate(
+                    field,
+                    FieldUtils.readField(field, bean, true) as Any,
+                    map?.get(failureKey),
+                    none,
+                  )
+                }
+              liftToEtr<FailureT, ValidatableT>(validator, none)
+            } else {
+              throw IllegalArgumentException(
+                "Provided Annotation is not supported. Please use supported annotations or custom annotations with valid instance. For more info please check official documentation.",
               )
             }
-          liftToEtr<FailureT, ValidatableT>(validator, none)
-        } else {
-          throw IllegalArgumentException(
-            "Provided Annotation is not supported. Please use supported annotations or custom annotations with valid instance. For more info please check official documentation."
-          )
+          }
+          "Negative" -> {
+            val annotation = field.getAnnotation(Negative::class.java)
+            val failureKey = annotation.failureKey
+            val negativeValidator =
+              NegativeValidator::class.java.getDeclaredConstructor().newInstance()
+                as ValidatorAnnotation1<Any, FailureT?>
+            validator =
+              Validator<ValidatableT?, FailureT?> {
+                negativeValidator.validate(
+                  field,
+                  FieldUtils.readField(field, bean, true) as Any,
+                  map?.get(failureKey),
+                  none,
+                )
+              }
+            liftToEtr<FailureT, ValidatableT>(validator, none)
+          }
+          "NonNegative" -> {
+            val annotation = field.getAnnotation(NonNegative::class.java)
+            val failureKey = annotation.failureKey
+            val nonNegativeValidator =
+              NonNegativeValidator::class.java.getDeclaredConstructor().newInstance()
+                as ValidatorAnnotation1<Any, FailureT?>
+            validator =
+              Validator<ValidatableT?, FailureT?> {
+                nonNegativeValidator.validate(
+                  field,
+                  FieldUtils.readField(field, bean, true) as Any,
+                  map?.get(failureKey),
+                  none,
+                )
+              }
+            liftToEtr<FailureT, ValidatableT>(validator, none)
+          }
+          "Positive" -> {
+            val annotation = field.getAnnotation(Positive::class.java)
+            val failureKey = annotation.failureKey
+            val positiveValidator =
+              PositiveValidator::class.java.getDeclaredConstructor().newInstance()
+                as ValidatorAnnotation1<Any, FailureT?>
+            validator =
+              Validator<ValidatableT?, FailureT?> {
+                positiveValidator.validate(
+                  field,
+                  FieldUtils.readField(field, bean, true) as Any,
+                  map?.get(failureKey),
+                  none,
+                )
+              }
+            liftToEtr<FailureT, ValidatableT>(validator, none)
+          }
+          "MaxForInt" -> {
+            val annotation = field.getAnnotation(MaxForInt::class.java)
+            val failureKey = annotation.failureKey
+            val maxIntValidator =
+              MaxForIntValidator::class.java.getDeclaredConstructor().newInstance()
+                as ValidatorAnnotation2<Any, FailureT?>
+            validator =
+              Validator<ValidatableT?, FailureT?> {
+                maxIntValidator.validate(
+                  field,
+                  FieldUtils.readField(field, bean, true) as Any,
+                  annotation.limit,
+                  map?.get(failureKey),
+                  none,
+                )
+              }
+            liftToEtr<FailureT, ValidatableT>(validator, none)
+          }
+          "MinForInt" -> {
+            val annotation = field.getAnnotation(MinForInt::class.java)
+            val failureKey = annotation.failureKey
+            val minIntValidator =
+              MinForIntValidator::class.java.getDeclaredConstructor().newInstance()
+                as ValidatorAnnotation2<Any, FailureT?>
+            validator =
+              Validator<ValidatableT?, FailureT?> {
+                minIntValidator.validate(
+                  field,
+                  FieldUtils.readField(field, bean, true) as Any,
+                  annotation.limit,
+                  map?.get(failureKey),
+                  none,
+                )
+              }
+            liftToEtr<FailureT, ValidatableT>(validator, none)
+          }
+          else -> null
         }
       } else {
         null

--- a/vador/src/main/java/com/salesforce/vador/execution/strategies/AnnotationProcessor.kt
+++ b/vador/src/main/java/com/salesforce/vador/execution/strategies/AnnotationProcessor.kt
@@ -36,120 +36,103 @@ object AnnotationProcessorBase {
     val none = mapOfAnnotation?._2()
     return fields.mapNotNull { field ->
       if (field.annotations.isNotEmpty()) {
-        val validator: Validator<ValidatableT?, FailureT?>
-        when (field.annotations[0].annotationClass.simpleName) {
-          "ValidateWith" -> {
-            val annotation = field.getAnnotation(ValidateWith::class.java)
-            val failureKey = annotation.failureKey
-            if (ValidatorAnnotation1::class.java.isAssignableFrom(annotation.validator.java)) {
-              val validatorAnnotation =
-                annotation.validator.java.getDeclaredConstructor().newInstance()
-                  as ValidatorAnnotation1<Any, FailureT?>
-              validator =
-                Validator<ValidatableT?, FailureT?> {
-                  validatorAnnotation.validate(
-                    field,
-                    FieldUtils.readField(field, bean, true) as Any,
-                    map?.get(failureKey),
-                    none,
+        val validator: Validator<ValidatableT?, FailureT?> =
+          when (field.annotations[0].annotationClass) {
+            ValidateWith::class -> {
+              val annotation = field.getAnnotation(ValidateWith::class.java)
+              when {
+                ValidatorAnnotation1::class.java.isAssignableFrom(annotation.validator.java) -> {
+                  val validatorAnnotation =
+                    annotation.validator.java.getDeclaredConstructor().newInstance()
+                      as ValidatorAnnotation1<Any, FailureT?>
+                  Validator<ValidatableT?, FailureT?> {
+                    validatorAnnotation.validate(
+                      field,
+                      FieldUtils.readField(field, bean, true) as Any,
+                      map?.get(annotation.failureKey),
+                      none,
+                    )
+                  }
+                }
+                else -> {
+                  throw IllegalArgumentException(
+                    "Provided Annotation is not supported. Please use supported annotations or custom annotations with valid instance. For more info please check official documentation."
                   )
                 }
-              liftToEtr<FailureT, ValidatableT>(validator, none)
-            } else {
-              throw IllegalArgumentException(
-                "Provided Annotation is not supported. Please use supported annotations or custom annotations with valid instance. For more info please check official documentation.",
-              )
+              }
             }
-          }
-          "Negative" -> {
-            val annotation = field.getAnnotation(Negative::class.java)
-            val failureKey = annotation.failureKey
-            val negativeValidator =
-              NegativeValidator::class.java.getDeclaredConstructor().newInstance()
-                as ValidatorAnnotation1<Any, FailureT?>
-            validator =
+            Negative::class -> {
+              val negativeValidator =
+                NegativeValidator::class.java.getDeclaredConstructor().newInstance()
+                  as ValidatorAnnotation1<Any, FailureT?>
               Validator<ValidatableT?, FailureT?> {
                 negativeValidator.validate(
                   field,
                   FieldUtils.readField(field, bean, true) as Any,
-                  map?.get(failureKey),
+                  map?.get(field.getAnnotation(Negative::class.java).failureKey),
                   none,
                 )
               }
-            liftToEtr<FailureT, ValidatableT>(validator, none)
-          }
-          "NonNegative" -> {
-            val annotation = field.getAnnotation(NonNegative::class.java)
-            val failureKey = annotation.failureKey
-            val nonNegativeValidator =
-              NonNegativeValidator::class.java.getDeclaredConstructor().newInstance()
-                as ValidatorAnnotation1<Any, FailureT?>
-            validator =
+            }
+            NonNegative::class -> {
+              val nonNegativeValidator =
+                NonNegativeValidator::class.java.getDeclaredConstructor().newInstance()
+                  as ValidatorAnnotation1<Any, FailureT?>
               Validator<ValidatableT?, FailureT?> {
                 nonNegativeValidator.validate(
                   field,
                   FieldUtils.readField(field, bean, true) as Any,
-                  map?.get(failureKey),
+                  map?.get(field.getAnnotation(NonNegative::class.java).failureKey),
                   none,
                 )
               }
-            liftToEtr<FailureT, ValidatableT>(validator, none)
-          }
-          "Positive" -> {
-            val annotation = field.getAnnotation(Positive::class.java)
-            val failureKey = annotation.failureKey
-            val positiveValidator =
-              PositiveValidator::class.java.getDeclaredConstructor().newInstance()
-                as ValidatorAnnotation1<Any, FailureT?>
-            validator =
+            }
+            Positive::class -> {
+              val positiveValidator =
+                PositiveValidator::class.java.getDeclaredConstructor().newInstance()
+                  as ValidatorAnnotation1<Any, FailureT?>
               Validator<ValidatableT?, FailureT?> {
                 positiveValidator.validate(
                   field,
                   FieldUtils.readField(field, bean, true) as Any,
-                  map?.get(failureKey),
+                  map?.get(field.getAnnotation(Positive::class.java).failureKey),
                   none,
                 )
               }
-            liftToEtr<FailureT, ValidatableT>(validator, none)
-          }
-          "MaxForInt" -> {
-            val annotation = field.getAnnotation(MaxForInt::class.java)
-            val failureKey = annotation.failureKey
-            val maxIntValidator =
-              MaxForIntValidator::class.java.getDeclaredConstructor().newInstance()
-                as ValidatorAnnotation2<Any, FailureT?>
-            validator =
+            }
+            MaxForInt::class -> {
+              val annotation = field.getAnnotation(MaxForInt::class.java)
+              val maxIntValidator =
+                MaxForIntValidator::class.java.getDeclaredConstructor().newInstance()
+                  as ValidatorAnnotation2<Any, FailureT?>
               Validator<ValidatableT?, FailureT?> {
                 maxIntValidator.validate(
                   field,
                   FieldUtils.readField(field, bean, true) as Any,
                   annotation.limit,
-                  map?.get(failureKey),
+                  map?.get(annotation.failureKey),
                   none,
                 )
               }
-            liftToEtr<FailureT, ValidatableT>(validator, none)
-          }
-          "MinForInt" -> {
-            val annotation = field.getAnnotation(MinForInt::class.java)
-            val failureKey = annotation.failureKey
-            val minIntValidator =
-              MinForIntValidator::class.java.getDeclaredConstructor().newInstance()
-                as ValidatorAnnotation2<Any, FailureT?>
-            validator =
+            }
+            MinForInt::class -> {
+              val annotation = field.getAnnotation(MinForInt::class.java)
+              val minIntValidator =
+                MinForIntValidator::class.java.getDeclaredConstructor().newInstance()
+                  as ValidatorAnnotation2<Any, FailureT?>
               Validator<ValidatableT?, FailureT?> {
                 minIntValidator.validate(
                   field,
                   FieldUtils.readField(field, bean, true) as Any,
                   annotation.limit,
-                  map?.get(failureKey),
+                  map?.get(annotation.failureKey),
                   none,
                 )
               }
-            liftToEtr<FailureT, ValidatableT>(validator, none)
+            }
+            else -> Validator<ValidatableT?, FailureT?> { null }
           }
-          else -> null
-        }
+        liftToEtr<FailureT, ValidatableT>(validator, none)
       } else {
         null
       }

--- a/vador/src/main/java/com/salesforce/vador/types/Validators.kt
+++ b/vador/src/main/java/com/salesforce/vador/types/Validators.kt
@@ -19,3 +19,13 @@ fun interface ValidatorEtr<ValidatableT, FailureT> :
 fun interface ValidatorAnnotation1<FieldT, FailureT> {
   fun validate(field: Field, value: FieldT, failure: FailureT, none: FailureT): FailureT
 }
+
+fun interface ValidatorAnnotation2<FieldT, FailureT> {
+  fun validate(
+    field: Field,
+    value1: FieldT,
+    value2: FieldT,
+    failure: FailureT,
+    none: FailureT
+  ): FailureT
+}

--- a/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
+++ b/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
@@ -165,7 +165,6 @@ public class VadorAnnotationTest {
     ID idOne;
   }
 
-  
   @Value
   private static class BeanInt {
     @MaxForInt(limit = 100, failureKey = "unexpectedException")
@@ -174,7 +173,7 @@ public class VadorAnnotationTest {
     @MinForInt(limit = 500, failureKey = "unexpectedException")
     int idTwo;
   }
-
+  
   static class ID {
     String value;
 

--- a/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
+++ b/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
@@ -173,7 +173,7 @@ public class VadorAnnotationTest {
     @MinForInt(limit = 500, failureKey = "unexpectedException")
     int idTwo;
   }
-  
+
   static class ID {
     String value;
 

--- a/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
+++ b/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
@@ -10,6 +10,7 @@ import com.salesforce.vador.annotation.MinForInt;
 import com.salesforce.vador.annotation.Negative;
 import com.salesforce.vador.annotation.NonNegative;
 import com.salesforce.vador.annotation.Positive;
+import com.salesforce.vador.annotation.TestAnnotation;
 import com.salesforce.vador.annotation.ValidateWith;
 import com.salesforce.vador.config.ValidationConfig;
 import com.salesforce.vador.types.ValidatorAnnotation1;
@@ -123,6 +124,16 @@ public class VadorAnnotationTest {
     assertThat(result).contains(UNKNOWN_EXCEPTION);
   }
 
+  @Test
+  void failFastWithFirstFailureWithValidatorAnnotationNotDefinedByVador() {
+    final var validationConfig =
+        ValidationConfig.<VadorAnnotationTest.BeanFailure, ValidationFailure>toValidate()
+            .forAnnotations(Tuple.of(Map.of("unexpectedException", UNKNOWN_EXCEPTION), NONE))
+            .prepare();
+    final var result = Vador.validateAndFailFast(new BeanFailure(-9), validationConfig);
+    assertThat(result).isEmpty();
+  }
+
   @Value
   private static class Bean {
     @Positive(failureKey = "unexpectedException")
@@ -172,6 +183,12 @@ public class VadorAnnotationTest {
 
     @MinForInt(limit = 500, failureKey = "unexpectedException")
     int idTwo;
+  }
+
+  @Value
+  private static class BeanFailure {
+    @TestAnnotation(testParam = 100)
+    int idOne;
   }
 
   static class ID {

--- a/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
+++ b/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
@@ -36,8 +36,6 @@ public class VadorAnnotationTest {
 
   private static final BeanCustom3 VALIDATBLECUSTOM3 = new BeanCustom3(new ID("Test Class1"));
 
-  private static final BeanInt VALIDATABLEINT = new BeanInt(99, 1000);
-
   @Test
   void failFastWithFirstFailureWithValidatorAnnotation() {
     final var validationConfig =
@@ -110,7 +108,7 @@ public class VadorAnnotationTest {
         ValidationConfig.<VadorAnnotationTest.BeanInt, ValidationFailure>toValidate()
             .forAnnotations(Tuple.of(Map.of("unexpectedException", UNKNOWN_EXCEPTION), NONE))
             .prepare();
-    final var result = Vador.validateAndFailFast(VALIDATABLEINT, validationConfig);
+    final var result = Vador.validateAndFailFast(new BeanInt(99, 1000), validationConfig);
     assertThat(result).isEmpty();
   }
 

--- a/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
+++ b/vador/src/test/java/com/salesforce/vador/execution/VadorAnnotationTest.java
@@ -140,7 +140,7 @@ public class VadorAnnotationTest {
     @Positive(failureKey = "unexpectedException")
     int idOne;
 
-    @Negative(validator = Negative.class, failureKey = "unexpectedException")
+    @Negative(failureKey = "unexpectedException")
     String idTwo;
   }
 

--- a/vador/src/test/kotlin/com/salesforce/vador/annotation/TestAnnotation.kt
+++ b/vador/src/test/kotlin/com/salesforce/vador/annotation/TestAnnotation.kt
@@ -1,0 +1,5 @@
+package com.salesforce.vador.annotation
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class TestAnnotation(val testParam: Int)


### PR DESCRIPTION
This PR contains Annotation feature for Vador framework. 

This will add 2 annotations.
1. MinForInt
2. MaxForInt
> A user can use these on field level and needs to pass 2 params (limit and failureKey) while consuming, i.e. limit (Int), failureKey (String)

I have also updated existing annotations - Negative, NonNegative and Positive.
> A user can use these on field level and needs to pass 1 param (failureKey) while consuming, i.e failureKey (String)

Added & updated tests to cover all possible flows.