### PR TITLE
Update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,21 @@
 name: Run Gradle on Push
 on: push
+permissions:
+  contents: read
 jobs:
   gradle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 25
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
 
       - name: Execute Gradle build
         run: ./gradlew build --warning-mode all


### PR DESCRIPTION
## Summary

- update checkout to v6, setup-java to v5, and setup-gradle to v6
- grant explicit read-only contents permission
- use the basic Gradle cache provider to preserve open-source caching behavior

## Reason

The post-merge master run passed but reported Node 20 and setup-java v4 deprecation annotations. This follow-up uses the current official action majors.

## Verification

- workflow diff check passed locally
- GitHub Actions will validate the workflow and run the full Gradle build